### PR TITLE
Upgrade for Laravel 8.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     }
   ],
   "require": {
-    "laravel/framework": "^7.0",
+    "laravel/framework": "^8.0",
     "vlucas/phpdotenv": "^4.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "laravel/framework": "^8.0",
-    "vlucas/phpdotenv": "^4.0"
+    "vlucas/phpdotenv": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/ConfiguresApplication.php
+++ b/src/ConfiguresApplication.php
@@ -4,10 +4,7 @@ namespace DFurnes\Environmentalist;
 
 use Closure;
 use Dotenv\Dotenv;
-use Dotenv\Repository\Adapter\EnvConstAdapter;
-use Dotenv\Repository\Adapter\PutenvAdapter;
-use Dotenv\Repository\Adapter\ServerConstAdapter;
-use Dotenv\Repository\RepositoryBuilder;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Symfony\Component\Console\Output\NullOutput;
@@ -151,16 +148,7 @@ trait ConfiguresApplication
      */
     protected function reloadEnvironment()
     {
-        $adapters = [
-            new EnvConstAdapter(),
-            new PutenvAdapter(),
-            new ServerConstAdapter(),
-        ];
-
-        $repository = RepositoryBuilder::create()
-            ->withReaders($adapters)
-            ->withWriters($adapters)
-            ->make();
+        $repository = Env::getRepository();
 
         // Reload the environment variables from the file.
         Dotenv::create($repository, app()->environmentPath(), null)->load();


### PR DESCRIPTION
This pull request makes Environmentalist compatible with Laravel 8.x, including a newer [phpdotenv](https://github.com/vlucas/phpdotenv) release.